### PR TITLE
Clarify comment about handling invalid nodes

### DIFF
--- a/ssoUsernameByOrg.py
+++ b/ssoUsernameByOrg.py
@@ -120,11 +120,14 @@ headers = {
     'accept-encoding': 'gzip',
 }
 
-# Some user nodes may come back from the GraphQL query in an incomplete state
-# (accurately reflecting how GitHub is storing it). We'll treat those as a
-# special case (print to stderr instead). Those users may need to fix issues
-# with their GitHub accounts before the SAML identity resolution will work for
-# the org.
+# Some user nodes may come back from the GraphQL query in an incomplete state.
+# This can happen if a user goes through SSO linking steps only partially.
+# We'll make a note of the invalid nodes in a temporary list and treat them as
+# a special case (print to stderr instead of stdout). Those users may need to
+# fix issues with their GitHub accounts or retry joining the org before the
+# SAML identity resolution will work for the org. If you don't want to include
+# the invalid entries in your CSV, you can redirect the stderr stream when you
+# invoke this script in your shell.
 invalidNodeList = []
 
 hasNextPage = True


### PR DESCRIPTION
More info based on what I heard from GitHub support. We're doing the right thing by simply ignoring the invalid nodes, but instructors may want to know who didn't finish linking properly.

It seems there is no way to filter out the invalid nodes at the request level or to remove the SAML link record.