### PR TITLE
fix for correctness: maybe data is returned but is None or empty somehow

### DIFF
--- a/ssoUsernameByOrg.py
+++ b/ssoUsernameByOrg.py
@@ -153,10 +153,12 @@ while hasNextPage:
             except:
                 nodeIsValid = False
                 samlId = None
-            if username is None:
+            if username in (None, ""):
+                nodeIsValid = False
                 username = ''
                 print("!!! Warning: Could not read GitHub username from node", file=sys.stderr)
-            if samlId is None:
+            if samlId in (None, ""):
+                nodeIsValid = False
                 samlId = ''
                 print("!!! Warning: Could not read SAML identity from node", file=sys.stderr)
             if nodeIsValid:


### PR DESCRIPTION
I think it's possible that a field could be None or "" without triggering the exception, so we should explicitly mark the node invalid.